### PR TITLE
Always returns an encoded URI

### DIFF
--- a/lib/batch-get.js
+++ b/lib/batch-get.js
@@ -36,8 +36,8 @@ module.exports = opts => {
 					// Handle failures
 					metrics.count(`${table}_status_4xx`);
 					return {
-						fromURL,
-						toURL: fromURL,
+						fromURL: encodeURI(fromURL),
+						toURL: encodeURI(fromURL),
 						code: 100
 					};
 				});

--- a/lib/decode-dynamo-object.js
+++ b/lib/decode-dynamo-object.js
@@ -2,8 +2,8 @@
 
 module.exports = dynamoObject => {
 	return {
-		fromURL: dynamoObject.FromURL.S,
-		toURL: dynamoObject.ToURL.S,
+		fromURL: encodeURI(dynamoObject.FromURL.S),
+		toURL: encodeURI(dynamoObject.ToURL.S),
 		code: parseInt(dynamoObject.Code.N, 10)
 	};
 };

--- a/lib/get.js
+++ b/lib/get.js
@@ -29,8 +29,8 @@ module.exports = opts => {
 				}
 				metrics.count(`${table}_status_4xx`);
 				return {
-					fromURL,
-					toURL: fromURL,
+					fromURL: encodeURI(fromURL),
+					toURL: encodeURI(fromURL),
 					code: 100
 				};
 			}, err => {

--- a/main.js
+++ b/main.js
@@ -18,14 +18,14 @@ exports.get = fromURL => {
 	if (fromURL !== 'https://www.ft.com/' && fromURL[fromURL.length - 1] === '/') {
 		const trimmedURL = fromURL.replace(/\/+$/, '');
 		return Promise.resolve({
-			fromURL,
-			toURL: trimmedURL,
+			fromURL: encodeURI(fromURL),
+			toURL: encodeURI(trimmedURL),
 			code: 301
 		});
 	} else if (fromURL === 'https://www.ft.com/') {
 		return Promise.resolve({
-			fromURL,
-			toURL: fromURL,
+			fromURL: encodeURI(fromURL),
+			toURL: encodeURI(fromURL),
 			code: 100
 		});
 	}

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -76,17 +76,6 @@ describe('#get', () => {
 			});
 	});
 
-	it('should decode non-ascii characters', () => {
-		return main.get('https://www.ft.com/f%C3%A4stft')
-			.then(data => {
-				expect(data).to.eql({
-					code: 100,
-					fromURL: 'https://www.ft.com/fästft',
-					toURL: 'https://www.ft.com/stream/brandId/NTlhNzEyMzMtZjBjZi00Y2U1LTg0ODUtZWVjNmEyYmU1NzQ2-QnJhbmRzä'
-				});
-			});
-	});
-
 	it('shouldn\'t redirect urls with trailing slashes to the slash-less url if that URL is only a /', () => {
 		return main.get('https://www.ft.com/')
 			.then(data => {


### PR DESCRIPTION
Incoming urls had to be decoded so we could do the look up, they were
never then being encoded when the api responded.

I believe this is part of the cause of this these errors in sentry
https://sentry.io/nextftcom/ft-next-preflight/issues/163868274/

The underlying issue that causes all of this, the fact the url's contain
these characters in the first place, has yet to be resolved but this
will at least mean valid urls are passed back and that the headers can
be set

/cc @debugwand @TheoLeanse @phamann

The test that is currently failing was left intentionally failing to see what people believe the correct behaviour of this module/api should be

Are there cases where it should return `fästft` and not `f%C3%A4stft`?