### PR TITLE
Unpin @financial-times/n-gage

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "denodeify": "^1.2.1"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "3.4.0",
+    "@financial-times/n-gage": "^3.6.0",
     "chai": "^3.5.0",
     "eslint": "^1.10.3",
     "istanbul": "^0.4.2",


### PR DESCRIPTION
This pull requests unpins the @financial-times/n-gage dependency. As a general rule we should not be pinning any of our devDependencies. Please merge this pull requests if all checks are passing.