### PR TITLE
fix: add id to pass validation for healthchecks checks

### DIFF
--- a/lib/health.js
+++ b/lib/health.js
@@ -7,7 +7,7 @@ exports.check = opts => {
 		getStatus: () => {
 			return {
 				name: 'n-url-management-api-read-client health check',
-				id: 'n-url-management-api-read-client-failure-mode',
+				id: 'nUrlManApiRC-fm',
 				ok: !active.totalFailure(),
 				checkOutput: `Total failure mode (can't reach either master or slave DynamoDBs) when following is true: ${active.totalFailure()}.  Currently using ${active()} table.`,
 				lastUpdated: new Date(),

--- a/lib/health.js
+++ b/lib/health.js
@@ -7,7 +7,7 @@ exports.check = opts => {
 		getStatus: () => {
 			return {
 				name: 'n-url-management-api-read-client health check',
-				id: 'nUrlManApiRC-fm',
+				id: 'nUrlManagementApiRC-failureMode',
 				ok: !active.totalFailure(),
 				checkOutput: `Total failure mode (can't reach either master or slave DynamoDBs) when following is true: ${active.totalFailure()}.  Currently using ${active()} table.`,
 				lastUpdated: new Date(),

--- a/lib/health.js
+++ b/lib/health.js
@@ -7,6 +7,7 @@ exports.check = opts => {
 		getStatus: () => {
 			return {
 				name: 'n-url-management-api-read-client health check',
+				id: 'n-url-management-api-read-client-failure-mode',
 				ok: !active.totalFailure(),
 				checkOutput: `Total failure mode (can't reach either master or slave DynamoDBs) when following is true: ${active.totalFailure()}.  Currently using ${active()} table.`,
 				lastUpdated: new Date(),


### PR DESCRIPTION
As explained in [this PR](https://github.com/Financial-Times/next-preflight/pull/521) every check should have and unique id, so Heimdall is happy and can provide a Grafana chart with the relative health check.