### PR TITLE
Remove unused CircleCI Lambda Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,6 @@ references:
     docker:
       - image: circleci/node:8-browsers
 
-  container_config_lambda_node8: &container_config_lambda_node8
-    working_directory: ~/project/build
-    docker:
-      - image: lambci/lambda:build-nodejs8.10
-
   workspace_root: &workspace_root
     ~/project
 


### PR DESCRIPTION
The CircleCI config file contains a Lambda Docker image that is not used and so is removed by this PR.<br/><br/>This PR was created using a [nori](https://github.com/Financial-Times/nori) script 🍙<br/><br/>*Nori is a command-line application for managing changes across multiple (usually Github) repositories.*