### PR TITLE
CPP-456 Rename dynamodb tables

### DIFF
--- a/lib/active.js
+++ b/lib/active.js
@@ -7,7 +7,7 @@ const surviver = require('./promise-surviver');
 
 const HEALTHCHECK_URL = 'https://www.ft.com/__$HEALTHCHECK';
 
-let dynamoInUse = 'master';
+let dynamoInUse = 'primary';
 let totalFailure = false;
 let metrics;
 
@@ -17,15 +17,15 @@ module.exports.totalFailure = () => totalFailure;
 
 function raceDynamos () {
 	return surviver([
-		get({ dynamo: dynamos.get('master').instance, table: dynamos.get('master').table, fromURL: HEALTHCHECK_URL, metrics: metrics }).then(() => 'master'),
-		get({ dynamo: dynamos.get('slave').instance, table: dynamos.get('slave').table, fromURL: HEALTHCHECK_URL, metrics: metrics }).then(() => 'slave')
+		get({ dynamo: dynamos.get('primary').instance, table: dynamos.get('primary').table, fromURL: HEALTHCHECK_URL, metrics: metrics }).then(() => 'primary'),
+		get({ dynamo: dynamos.get('replica').instance, table: dynamos.get('replica').table, fromURL: HEALTHCHECK_URL, metrics: metrics }).then(() => 'replica')
 	])
 		.then(fasterDynamo => {
 			dynamoInUse = fasterDynamo;
 			logger.info({ event: 'RACE_DYNAMOS_WINNER', dynamoInUse: dynamoInUse });
 			totalFailure = false;
 		}, () => {
-			dynamoInUse = 'master';
+			dynamoInUse = 'primary';
 			logger.warn({ event: 'RACE_DYNAMOS_NO_WINNERS', dynamoInUse: dynamoInUse });
 			totalFailure = true;
 		});
@@ -35,7 +35,7 @@ function raceDynamos () {
 function init (opts) {
 	dynamos.init(opts);
 	metrics = opts.metrics;
-	dynamoInUse = 'master';
+	dynamoInUse = 'primary';
 	totalFailure = false;
 	if (!opts.raceOnce) {
 		setInterval(raceDynamos, 2*60*1000);

--- a/lib/dynamos.js
+++ b/lib/dynamos.js
@@ -30,8 +30,8 @@ const dynamos = {};
 
 module.exports.init = function (opts) {
 	opts = opts || {};
-	dynamos.master = dynamo('urlmgmtapi_master', 'eu-west-1', opts);
-	dynamos.slave = dynamo('urlmgmtapi_slave', 'us-east-1', opts)
+	dynamos.primary = dynamo('urlmgmtapi_primary', 'eu-west-1', opts);
+	dynamos.replica = dynamo('urlmgmtapi_replica', 'us-east-1', opts)
 }
 
 module.exports.get = name => dynamos[name];

--- a/lib/health.js
+++ b/lib/health.js
@@ -9,7 +9,7 @@ exports.check = opts => {
 				name: 'n-url-management-api-read-client health check',
 				id: 'nUrlManagementApiRC-failureMode',
 				ok: !active.totalFailure(),
-				checkOutput: `Total failure mode (can't reach either master or slave DynamoDBs) when following is true: ${active.totalFailure()}.  Currently using ${active()} table.`,
+				checkOutput: `Total failure mode (can't reach either primary or replica DynamoDBs) when following is true: ${active.totalFailure()}.  Currently using ${active()} table.`,
 				lastUpdated: new Date(),
 				panicGuide: `Try checking the \`URLMGMTAPI_AWS_ACCESS/SECRET_KEY\`s and the status of DynamoDB in both eu-west-1 and us-east-1`,
 				severity: opts.severity,

--- a/test/active.single-region-failure.test.js
+++ b/test/active.single-region-failure.test.js
@@ -11,16 +11,16 @@ const active = proxyquire('../lib/active', {
 		get: function (name) {
 			return this[name];
 		},
-		master: {
-			table: 'urlmgmtapi_master',
+		primary: {
+			table: 'urlmgmtapi_primary',
 			instance: {
 				getItem: (opts, cb) => {
-					setTimeout(() => cb(new Error('master failure')), 100);
+					setTimeout(() => cb(new Error('primary failure')), 100);
 				}
 			}
 		},
-		slave: {
-			table: 'urlmgmtapi_slave',
+		replica: {
+			table: 'urlmgmtapi_replica',
 			instance: {
 				getItem: (opts, cb) => {
 					setTimeout(() => cb(null, itemFixture), 300);
@@ -34,13 +34,13 @@ describe('#active in a single region failure mode', () => {
 
 	before(() => active.init({ metrics: metricsMock }));
 
-	it('should start off being ‘master’', () => {
-		expect(active()).to.eql('master');
+	it('should start off being ‘primary’', () => {
+		expect(active()).to.eql('primary');
 	});
 
 	it('should use the healthy region', done => {
 		setTimeout(() => {
-			expect(active()).to.eql('slave');
+			expect(active()).to.eql('replica');
 			expect(active.totalFailure()).to.be.false;
 			done();
 		}, 500);

--- a/test/active.test.js
+++ b/test/active.test.js
@@ -13,16 +13,16 @@ const active = proxyquire('../lib/active', {
 		get: function (name) {
 			return this[name];
 		},
-		master: {
-			table: 'urlmgmtapi_master',
+		primary: {
+			table: 'urlmgmtapi_primary',
 			instance: {
 				getItem: (opts, cb) => {
 					setTimeout(() => cb(null, itemFixture), 300);
 				}
 			}
 		},
-		slave: {
-			table: 'urlmgmtapi_slave',
+		replica: {
+			table: 'urlmgmtapi_replica',
 			instance: {
 				getItem: (opts, cb) => {
 					setTimeout(() => cb(null, itemFixture), 100);
@@ -40,13 +40,13 @@ describe('#active', () => {
 		expect(dynamosInitStub.calledWith(opts)).to.be.true;
 	});
 
-	it('should start off being ‘master’', () => {
-		expect(active()).to.eql('master');
+	it('should start off being ‘primary’', () => {
+		expect(active()).to.eql('primary');
 	});
 
 	it('should prefer the faster region after the healthcheck has run', done => {
 		setTimeout(() => {
-			expect(active()).to.eql('slave');
+			expect(active()).to.eql('replica');
 			expect(active.totalFailure()).to.be.false;
 			done();
 		}, 500);

--- a/test/active.total-failure.test.js
+++ b/test/active.total-failure.test.js
@@ -10,19 +10,19 @@ const active = proxyquire('../lib/active', {
 		get: function (name) {
 			return this[name];
 		},
-		master: {
-			table: 'urlmgmtapi_master',
+		primary: {
+			table: 'urlmgmtapi_primary',
 			instance: {
 				getItem: (opts, cb) => {
-					setTimeout(() => cb(new Error('master failure')), 150)
+					setTimeout(() => cb(new Error('primary failure')), 150)
 				}
 			}
 		},
-		slave: {
-			table: 'urlmgmtapi_slave',
+		replica: {
+			table: 'urlmgmtapi_replica',
 			instance: {
 				getItem: (opts, cb) => {
-					setTimeout(() => cb(new Error('slave failure')), 100)
+					setTimeout(() => cb(new Error('replica failure')), 100)
 				}
 			}
 		}
@@ -34,13 +34,13 @@ describe('#active in a total failure mode', () => {
 
 	before(() => active.init({ metrics: metricsMock }));
 
-	it('should start off being ‘master’', () => {
-		expect(active()).to.eql('master');
+	it('should start off being ‘primary’', () => {
+		expect(active()).to.eql('primary');
 	});
 
-	it('should just use master and hope for the best', done => {
+	it('should just use primary and hope for the best', done => {
 		setTimeout(() => {
-			expect(active()).to.eql('master');
+			expect(active()).to.eql('primary');
 			expect(active.totalFailure()).to.be.true;
 			done();
 		}, 200);

--- a/test/batch-get.test.js
+++ b/test/batch-get.test.js
@@ -10,7 +10,7 @@ const mockInstance = {
 	batchGetItem: (opts, cb) => {
 		cb(null, {
 			Responses: {
-				urlmgmtapi_master: [
+				urlmgmtapi_primary: [
 					fastFtFixture.Item,
 					justasFastFtFixture.Item
 				]
@@ -25,8 +25,8 @@ const main = proxyquire('..', {
 		get: function (name) {
 			return this[name];
 		},
-		master: { table: 'urlmgmtapi_master', instance: mockInstance },
-		slave: { table: 'urlmgmtapi_slave', instance: mockInstance }
+		primary: { table: 'urlmgmtapi_primary', instance: mockInstance },
+		replica: { table: 'urlmgmtapi_replica', instance: mockInstance }
 	}
 });
 

--- a/test/dynamos.test.js
+++ b/test/dynamos.test.js
@@ -10,7 +10,7 @@ describe('#dynamos', () => {
 	beforeEach(() => sinon.stub(dynamos, '_createDynamoDBInstance'));
 	afterEach(() => dynamos._createDynamoDBInstance.restore())
 
-	it('should initialise master and slave instances', () => {
+	it('should initialise primary and replica instances', () => {
 		dynamos.init();
 		expect(dynamos._createDynamoDBInstance.args[0][0]).to.deep.equal({
 			region: 'eu-west-1',
@@ -26,9 +26,9 @@ describe('#dynamos', () => {
 		})
 	})
 
-	it('should be possible to get master or slave', () => {
-		expect(dynamos.get('master').table).to.equal('urlmgmtapi_master')
-		expect(dynamos.get('slave').table).to.equal('urlmgmtapi_slave')
+	it('should be possible to get primary or replica', () => {
+		expect(dynamos.get('primary').table).to.equal('urlmgmtapi_primary')
+		expect(dynamos.get('replica').table).to.equal('urlmgmtapi_replica')
 	});
 
 	it('should pass http options', () => {

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -28,8 +28,8 @@ const main = proxyquire('..', {
 		get: function (name) {
 			return this[name];
 		},
-		master: { table: 'urlmgmtapi_master', instance: mockInstance },
-		slave: { table: 'urlmgmtapi_slave', instance: mockInstance }
+		primary: { table: 'urlmgmtapi_primary', instance: mockInstance },
+		replica: { table: 'urlmgmtapi_replica', instance: mockInstance }
 	}
 });
 

--- a/test/lib/get.test.js
+++ b/test/lib/get.test.js
@@ -18,7 +18,7 @@ describe('#get', () => {
 				fromURL: 'https://www.ft.com/unknown',
 				dynamo: mockInstance,
 				metrics: metricsMock,
-				table: 'urlmgmtapi_master',
+				table: 'urlmgmtapi_primary',
 				timeout: 500
 			})
 			.then(() => {


### PR DESCRIPTION
[Ticket CPP-456](https://financialtimes.atlassian.net/browse/CPP-456)

As an organisation we are moving away from the usage of unnecessary language that can be offensive. This PR is to change the names of dynamodb tables that were not complying.