### PR TITLE
Allow passing in AWS creds when initialising

### DIFF
--- a/lib/dynamos.js
+++ b/lib/dynamos.js
@@ -15,12 +15,28 @@ function dynamo (table, region, opts) {
 		httpOptions.connectTimeout = opts.connectTimeout
 	}
 
+	let accessKeyId = process.env.URLMGMTAPI_AWS_ACCESS_KEY || process.env.AWS_ACCESS_KEY;
+	let secretAccessKey = process.env.URLMGMTAPI_AWS_SECRET_KEY || process.env.AWS_SECRET_ACCESS_KEY;
+
+	if (opts.auth) {
+		if (!opts.auth.accessKeyId) {
+			throw new Error('accessKeyId not set on auth object');
+		}
+
+		if (!opts.auth.secretAccessKey) {
+			throw new Error('secretAccessKey not set on auth object');
+		}
+
+		accessKeyId = opts.auth.accessKeyId;
+		secretAccessKey = opts.auth.secretAccessKey;
+	}
+
 	return {
 		table,
 		instance: module.exports._createDynamoDBInstance({
 			region: region,
-			accessKeyId: process.env.URLMGMTAPI_AWS_ACCESS_KEY || process.env.AWS_ACCESS_KEY,
-			secretAccessKey: process.env.URLMGMTAPI_AWS_SECRET_KEY || process.env.AWS_SECRET_ACCESS_KEY,
+			accessKeyId,
+			secretAccessKey,
 			httpOptions
 		})
 	};

--- a/test/dynamos.test.js
+++ b/test/dynamos.test.js
@@ -44,4 +44,26 @@ describe('#dynamos', () => {
 		expect(httpOptions.agent instanceof Agent).to.be.true
 	});
 
+	describe('auth', () => {
+		it('should allow passing access key and secret', () => {
+			dynamos.init({
+				auth: {
+					accessKeyId: 'akia-test',
+					secretAccessKey: 'secret-secret'
+				}
+			});
+			expect(dynamos._createDynamoDBInstance.args[0][0].accessKeyId).to.equal('akia-test');
+			expect(dynamos._createDynamoDBInstance.args[0][0].secretAccessKey).to.equal('secret-secret');
+		});
+
+		it('throws an error if you do not pass in the key or secret', () => {
+			expect(function(){
+				dynamos.init({
+					auth: {
+						accessKeyId: 'akia-test'
+					}
+				});
+			}).to.throw('secretAccessKey not set on auth object');
+		});
+	});
 });


### PR DESCRIPTION
We need to use environment variables that end in _ACCESS_KEY_ID and _SECRET_ACCESS_KEY because Doppler says so.

In my opinion the better way to deal with that is to allow us to pass in authorisation when initialising the client. This means that the system is in control of what it names the environment variables.